### PR TITLE
Aktualizovane informacie o zavislostiach

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,11 @@ Implementovane parsery mzdovych softverov:
 
 Pre rozbehanie web rozhrania je nutne nainstalovat tieto baliky (plati pre systemy s Ubuntu):
 
-apt:
-- python-django
-
 python baliky:
+- pip install django
 - pip install django-bootstrap3
-- pip install easy\_pdf
+- pip install git+https://github.com/chrisglass/xhtml2pdf.git
 - pip install django-easy-pdf
-- pip install xhtml2pdf
 - pip install xmltodict
 
 Nasledne v adresari mojavyplata spustit:


### PR DESCRIPTION
apt dava staru verziu django; django-easy-pdf zavisi na git+https://github.com/chrisglass/xhtml2pdf.git

Tieto informácie sú možno špecifické pre mňa, no nemám to ako zistiť.